### PR TITLE
highlighted bean image links to content (bean page)

### DIFF
--- a/wetkit_bean.make
+++ b/wetkit_bean.make
@@ -21,3 +21,6 @@ projects[bean_panels][type] = module
 projects[bean_panels][download][type] = git
 projects[bean_panels][download][revision] = 3a7d7f2
 projects[bean_panels][download][branch] = 7.x-1.x
+
+projects[image_link_formatter][version] = 1.x-dev
+projects[image_link_formatter][subdir] = contrib

--- a/wetkit_bean_plugins/wetkit_bean_plugins.features.field_instance.inc
+++ b/wetkit_bean_plugins/wetkit_bean_plugins.features.field_instance.inc
@@ -57,12 +57,12 @@ function wetkit_bean_plugins_field_default_field_instances() {
     'display' => array(
       'default' => array(
         'label' => 'hidden',
-        'module' => 'image',
+        'module' => 'image_link_formatter',
         'settings' => array(
-          'image_link' => 'content',
+          'image_link' => 'field_bean_highlight_link',
           'image_style' => 'highlighted',
         ),
-        'type' => 'image',
+        'type' => 'image_link_formatter',
         'weight' => 2,
       ),
     ),

--- a/wetkit_bean_plugins/wetkit_bean_plugins.field_group.inc
+++ b/wetkit_bean_plugins/wetkit_bean_plugins.field_group.inc
@@ -56,9 +56,9 @@ function wetkit_bean_plugins_field_group_info() {
     'weight' => '1',
     'children' => array(
       0 => 'field_bean_highlight_description',
-      1 => 'field_bean_highlight_link_text',
+      1 => 'field_bean_highlight_image',
       2 => 'field_bean_highlight_link',
-      3 => 'field_bean_highlight_image',
+      3 => 'field_bean_highlight_link_text',
     ),
     'format_type' => 'div',
     'format_settings' => array(

--- a/wetkit_bean_plugins/wetkit_bean_plugins.info
+++ b/wetkit_bean_plugins/wetkit_bean_plugins.info
@@ -6,6 +6,7 @@ dependencies[] = ctools
 dependencies[] = features
 dependencies[] = field_group
 dependencies[] = image
+dependencies[] = image_link_formatter
 dependencies[] = link
 dependencies[] = list
 dependencies[] = media


### PR DESCRIPTION
unless there are legacy reasons why this is it is probably not the ideal behaviour. the link could just be removed but having the image link to the path entered in the linkfield might be more practical. I could just use [my own bean type](https://drupal.org/sandbox/discipolo/1972316) if there is a reason highlighted works this way, otherwise this pullrequest replaces the display formatter for highlighted image field with https://drupal.org/project/image_link_formatter
